### PR TITLE
Volume rendering improvements

### DIFF
--- a/anari/Volume.h
+++ b/anari/Volume.h
@@ -53,6 +53,8 @@ struct TransferFunction1D : public Volume
 
   box1 m_valueRange{0.f, 1.f};
   float m_densityScale{1.f};
+  math::float4 m_uniformColor{1.f, 1.f, 1.f, 1.f};
+  float m_uniformOpacity{1.f};
 
   helium::ChangeObserverPtr<helium::Array1D> m_colorData;
   helium::ChangeObserverPtr<helium::Array1D> m_opacityData;

--- a/barney/volume/MCAccelerator.h
+++ b/barney/volume/MCAccelerator.h
@@ -158,18 +158,23 @@ namespace BARNEY_NS {
     const void *pd = ti.getProgramData();
            
     const DD &self = *(typename MCVolumeAccel<SFSampler>::DD*)pd;
+    // ray in world space
     Ray &ray = *(Ray*)ti.getPRD();
     
     box3f bounds = self.volume.sfCommon.worldBounds;
     range1f tRange = { ti.getRayTmin(), ti.getRayTmax() };
     
-    if (!boxTest(ray,tRange,bounds))
-      return;
-    
-    // ray in world space
+    // ray in object space
     vec3f obj_org = ti.getObjectRayOrigin();
     vec3f obj_dir = ti.getObjectRayDirection();
 
+    auto objRay = ray;
+    objRay.org = obj_org;
+    objRay.dir = obj_dir;
+
+    if (!boxTest(objRay,tRange,bounds))
+      return;
+    
     // ------------------------------------------------------------------
     // compute ray in macro cell grid space 
     // ------------------------------------------------------------------

--- a/rtcore/embree/Texture.cpp
+++ b/rtcore/embree/Texture.cpp
@@ -225,6 +225,16 @@ namespace rtc {
       return vf * 1.f/255.f;
     }
 
+    template<>
+    vec4f getTexel<unsigned char>(TextureData *data,
+                                  const rtc::TextureDesc &desc,
+                                  int64_t idx)
+    {
+      if (idx < 0) return desc.borderColor;
+      unsigned char v = ((const unsigned char*)data->data.data())[idx];
+      vec4f  vf = vec4f(v);
+      return vf * 1.f/255.f;
+    }
 
     
     template<typename T>
@@ -435,6 +445,9 @@ namespace rtc {
                                   rtc::TextureDesc desc)
     {
       switch (data->format) {
+      case rtc::UCHAR:
+        return createSampler<unsigned char>(data,desc);
+        break;
       case rtc::UCHAR4:
         return createSampler<vec4uc>(data,desc);
         break;


### PR DESCRIPTION
- In BANARI, fall back to uniform color and opacity if no color/opacity arrays were provided.
- Add support for uint8 textures in Embree back-end.
- Fix volume rendering with (non-identity) instance transforms.