### PR TITLE
Updated signatures to match ANARI SDK

### DIFF
--- a/anari/Device.cpp
+++ b/anari/Device.cpp
@@ -462,7 +462,8 @@ namespace barney_device {
   int BarneyDevice::deviceGetProperty(const char *name,
                                       ANARIDataType type,
                                       void *mem,
-                                      uint64_t size)
+                                      uint64_t size, 
+                                      uint32_t mask)
   {
     std::string_view prop = name;
     if (prop == "extension" && type == ANARI_STRING_LIST) {

--- a/anari/Device.h
+++ b/anari/Device.h
@@ -108,7 +108,8 @@ namespace barney_device {
     int deviceGetProperty(const char *name,
                           ANARIDataType type,
                           void *mem,
-                          uint64_t size) override;
+                          uint64_t size,
+                          uint32_t mask) override;
     BarneyGlobalState *deviceState(bool commitOnDemand=true);
 
     bool m_initialized{false};

--- a/anari/Frame.cpp
+++ b/anari/Frame.cpp
@@ -130,7 +130,7 @@ void Frame::finalize()
 }
 
 bool Frame::getProperty(
-    const std::string_view &name, ANARIDataType type, void *ptr, uint32_t flags)
+    const std::string_view &name, ANARIDataType type, void *ptr, uint64_t size, uint32_t flags)
 {
   if (type == ANARI_FLOAT32 && name == "duration") {
     if (flags & ANARI_WAIT)

--- a/anari/Frame.h
+++ b/anari/Frame.h
@@ -25,6 +25,7 @@ namespace barney_device {
     bool getProperty(const std::string_view &name,
                      ANARIDataType type,
                      void *ptr,
+                     uint64_t size,
                      uint32_t flags) override;
 
     void commitParameters() override;

--- a/anari/Object.cpp
+++ b/anari/Object.cpp
@@ -25,7 +25,7 @@ void Object::finalize()
 }
 
 bool Object::getProperty(
-    const std::string_view &name, ANARIDataType type, void *ptr, uint32_t flags)
+    const std::string_view &name, ANARIDataType type, void *ptr, uint64_t size, uint32_t flags)
 {
   if (name == "valid" && type == ANARI_BOOL) {
     helium::writeToVoidP(ptr, isValid());

--- a/anari/Object.h
+++ b/anari/Object.h
@@ -21,6 +21,7 @@ struct Object : public helium::BaseObject
   bool getProperty(const std::string_view &name,
       ANARIDataType type,
       void *ptr,
+      uint64_t size,
       uint32_t flags) override;
 
   void commitParameters() override;

--- a/anari/World.cpp
+++ b/anari/World.cpp
@@ -42,6 +42,7 @@ namespace barney_device {
   bool World::getProperty(const std::string_view &name,
                           ANARIDataType type,
                           void *ptr,
+                          uint64_t size,
                           uint32_t flags)
   {
     if (name == "bounds" && type == ANARI_FLOAT32_BOX3) {
@@ -58,7 +59,7 @@ namespace barney_device {
       return true;
     }
 
-    return Object::getProperty(name, type, ptr, flags);
+    return Object::getProperty(name, type, ptr, size, flags);
   }
 
   void World::commitParameters()

--- a/anari/World.h
+++ b/anari/World.h
@@ -16,6 +16,7 @@ namespace barney_device {
     bool getProperty(const std::string_view &name,
                      ANARIDataType type,
                      void *ptr,
+                     uint64_t size,
                      uint32_t flags) override;
 
     void commitParameters() override;


### PR DESCRIPTION
The signatures for ```deviceGetProperties``` and ```getProperties``` changed in the ANARI SDK, this MR updates the methods in barney to comply with this changes and making it compile with the current next_release branch (31ceb921b6b4b038d8f1273317f17af8dd167eae)